### PR TITLE
Only set XDG_CONFIG_HOME if not already defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-XDG_CONFIG_HOME := $(HOME)/.config
+XDG_CONFIG_HOME ?= $(HOME)/.config
 
 .PHONY: install
 install: ## Sets up symlink for user and root .vimrc for vim and neovim.


### PR DESCRIPTION
Kudos for using `XDG_CONFIG_HOME`. However, this environment variable should only default to `~/.config` if not set in the environment. This PR ensures that the Makefile doesn’t override the user’s set preference.