### PR TITLE
Fix README.md regeneration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,15 @@ update-pathogen: ## Updates pathogen.
 
 .PHONY: README.md
 README.md: ## Generates and updates plugin info in README.md.
-	@sed '/Dockerfile/q' $@ > $@.new && mv $@.new $@
-	@git submodule --quiet foreach 'git remote get-url origin | sed -e "s#https://\\(.*\\)#* [\\1](&)#" -e "s#git://\\(.*\\)#* [\\1](&)#" -e "s/\\.git//"' >> $@
+	@{ \
+		sed '/Dockerfile/q' $@; \
+		git submodule --quiet foreach '\
+			git remote get-url origin \
+			| sed -e "s#https://\\(.*\\)#* [\\1](&)#" -e "s#git://\\(.*\\)#* [\\1](&)#" -e "s/\\.git//" \
+		'; \
+		echo; \
+		sed -n '/## Contributing/,$$p' $@; \
+	} >> $@.tmp && mv $@.tmp $@
 
 check_defined = \
 				$(strip $(foreach 1,$1, \

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ update-pathogen: ## Updates pathogen.
 
 .PHONY: README.md
 README.md: ## Generates and updates plugin info in README.md.
-	@sed -i '/Dockerfile/q' $@
-	@git  submodule --quiet foreach bash -c "echo -e \"* [\$$(git config --get remote.origin.url | sed 's#https://##' | sed 's#git://##' | sed 's/.git//')](\$$(git config --get remote.origin.url))\"" >> $@
+	@sed '/Dockerfile/q' $@ > $@.new && mv $@.new $@
+	@git submodule --quiet foreach 'git remote get-url origin | sed -e "s#https://\\(.*\\)#* [\\1](&)#" -e "s#git://\\(.*\\)#* [\\1](&)#" -e "s/\\.git//"' >> $@
 
 check_defined = \
 				$(strip $(foreach 1,$1, \


### PR DESCRIPTION
The current Makefile rule to regenerate the `README.md` deletes the last section of the README (everything after the plugins). It unfortunately also generally fails on macOS. This PR fixes this.

* The first commit fixes macOS behaviour:
  * `sed -i` works differently for BSD sed; additionally, [BSD sed has a bug](https://apple.stackexchange.com/q/361059/2392), which makes it advisable to just use a temporary file.
  * There’s a small substitution/quote bug in the second command (`.` → `\\.`). The commit  fixes this, simplifies the command, which incidentally also makes it run noticeably faster.
* The second commit rewrites the whole command to avoid deleting parts of the README.