### PR TITLE
Updated README.md to fix a mini typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ git submodule update --init
 ```
 
 ### Pathogen
-The vim dot files make use of the excellent [Pathogen](https://github.com/tpope/vim-pathogen) runtime path manager to install plugins and runtime files into their own private directiories.
+The vim dot files make use of the excellent [Pathogen](https://github.com/tpope/vim-pathogen) runtime path manager to install plugins and runtime files into their own private directories.
 
 Currently using version 2.4 of Pathogen
 


### PR DESCRIPTION
Changed:
```
### Pathogen
The vim dot files make use of the excellent [Pathogen](https://github.com/tpope/vim-pathogen) runtime path manager to install plugins and runtime files into their own private directiories.
```
to:
```
### Pathogen
The vim dot files make use of the excellent [Pathogen](https://github.com/tpope/vim-pathogen) runtime path manager to install plugins and runtime files into their own private directories.
```